### PR TITLE
DA Layer on remote instance and PM2

### DIFF
--- a/DA/package.json
+++ b/DA/package.json
@@ -1,7 +1,8 @@
 {
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "yarn tsx server.ts"
+    "dev": "pm2 start server.ts --interpreter ./node_modules/.bin/ts-node && pm2 logs",
+    "reset": "pm2 delete server"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/enclave/package.json
+++ b/enclave/package.json
@@ -14,8 +14,10 @@
         "watch": "^1.0.2"
     },
     "scripts": {
-        "dev": "yarn tsx server.ts 0",
-        "dev:recover": "yarn tsx server.ts 1"
+        "dev": "rm -f encryption_key.txt && mkdir -p bin && pm2 start scripts/enclave.sh && pm2 logs",
+        "reset": "pm2 delete enclave",
+        "start": "yarn tsx server.ts 0",
+        "start:recover": "yarn tsx server.ts 1"
     },
     "devDependencies": {
         "ts-node": "^10.9.1",

--- a/enclave/scripts/enclave.sh
+++ b/enclave/scripts/enclave.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+: '
+  In execution, this script is managed by PM2. On startup, yarn start is called.
+  In case the enclave crashes, yarn start:recover is called.
+'
+
+if [ -f "encryption_key.txt" ]
+then
+    yarn start:recover
+else
+    touch encryption_key.txt
+    yarn start
+fi

--- a/game/Board.ts
+++ b/game/Board.ts
@@ -104,8 +104,8 @@ export class Board {
      * the perspective of the client.
      */
     public printView(): void {
-        for (let r = 0; r < 25; r++) {
-            for (let c = 0; c < 25; c++) {
+        for (let r = 0; r < 10; r++) {
+            for (let c = 0; c < 10; c++) {
                 let tl: Tile = this.getTile({ r, c }, 0n);
                 let color;
                 const reset = "\x1b[0m";


### PR DESCRIPTION
1. DA layer now works properly on a remote environment. Tested with CLI
2. Enclave and DA layer processes are now managed by PM2. Tested with CLI
3. Reduced size of printView() board from 25x25 to 10x10. The reason is to prevent lag and buggy printing, which was occurring when printing 25x25.